### PR TITLE
Revert "Fallback for single-threaded WASM: avoid `Task.Run` crash and add timeout/cancellation UI"

### DIFF
--- a/BigCalculator/Pages/Index.razor
+++ b/BigCalculator/Pages/Index.razor
@@ -440,15 +440,7 @@
 
         using var countdownCts = new CancellationTokenSource();
         var countdownTask = RunCountdownAsync(countdownCts.Token);
-        Task<CalculationResult> calculationTask;
-        try
-        {
-            calculationTask = Task.Run(() => CalculateCore(snapshot, _calculationCts.Token), _calculationCts.Token);
-        }
-        catch (PlatformNotSupportedException)
-        {
-            calculationTask = Task.FromResult(CalculateCore(snapshot, _calculationCts.Token));
-        }
+        var calculationTask = Task.Run(() => CalculateCore(snapshot, _calculationCts.Token), _calculationCts.Token);
         _ = calculationTask.ContinueWith(task => _ = task.Exception, TaskContinuationOptions.OnlyOnFaulted);
 
         try
@@ -536,8 +528,8 @@
 
         try
         {
-            var inputAValue = 0;
-            var inputBValue = 0;
+            BigFloat inputAValue = 0;
+            BigFloat inputBValue = 0;
 
             token.ThrowIfCancellationRequested();
 


### PR DESCRIPTION
Reverts SunsetQuest/BigCalculator#5