### PR TITLE
Add log10, ln, exp and trig operations using BigFloat

### DIFF
--- a/BigCalculator/Pages/Index.razor
+++ b/BigCalculator/Pages/Index.razor
@@ -581,11 +581,17 @@
                 Op.Pow => ValidatePower(inputAValue, snapshot.InputBString),
                 Op.Root => ValidateRoot(inputAValue, snapshot.InputBString),
                 Op.Sqrt => ValidateSquareRoot(inputAValue),
-                Op.Log2 => ValidateLogarithm(inputAValue),
+                Op.Log2 => ValidateLog2(inputAValue),
+                Op.Log10 => ValidateLog10(inputAValue),
+                Op.Ln => ValidateNaturalLog(inputAValue),
+                Op.Exp => BigFloat.Exp(inputAValue),
                 Op.Abs => BigFloat.Abs(inputAValue),
                 Op.Neg => -inputAValue,
                 Op.ShiftRight => ValidateShift(inputAValue, snapshot.InputBString, false),
                 Op.ShiftLeft => ValidateShift(inputAValue, snapshot.InputBString, true),
+                Op.Sin => BigFloat.Sin(inputAValue),
+                Op.Cos => BigFloat.Cos(inputAValue),
+                Op.Tan => BigFloat.Tan(inputAValue),
                 _ => throw new NotImplementedException($"Operation {snapshot.Operation} not implemented")
             };
 
@@ -794,13 +800,31 @@
         return BigFloat.Sqrt(a);
     }
 
-    private BigFloat ValidateLogarithm(BigFloat a)
+    private BigFloat ValidateLog2(BigFloat a)
     {
         if (a <= 0)
         {
             throw new ArgumentException("Logarithm undefined for non-positive numbers");
         }
         return (BigFloat)BigFloat.Log2(a);
+    }
+
+    private BigFloat ValidateLog10(BigFloat a)
+    {
+        if (a <= 0)
+        {
+            throw new ArgumentException("Logarithm undefined for non-positive numbers");
+        }
+        return (BigFloat)BigFloat.Log10(a);
+    }
+
+    private BigFloat ValidateNaturalLog(BigFloat a)
+    {
+        if (a <= 0)
+        {
+            throw new ArgumentException("Logarithm undefined for non-positive numbers");
+        }
+        return (BigFloat)BigFloat.Log(a);
     }
 
     private BigFloat ValidateShift(BigFloat a, string bString, bool leftShift)


### PR DESCRIPTION
### Motivation
- Expose more of the BigFloat library's unary functions (logs, exponent, trig) to the calculator so users can perform common scientific operations.
- Ensure logarithm operations validate their inputs to avoid domain errors for non-positive values.

### Description
- Updated `Pages/Index.razor` to map `Op.Log10`, `Op.Ln`, and `Op.Exp` to `BigFloat.Log10`, `BigFloat.Log`, and `BigFloat.Exp`, respectively, and to map `Op.Sin`, `Op.Cos`, and `Op.Tan` to `BigFloat.Sin`, `BigFloat.Cos`, and `BigFloat.Tan`.
- Replaced the previous `ValidateLogarithm` with `ValidateLog2` and added `ValidateLog10` and `ValidateNaturalLog` helper methods that throw for non-positive inputs.
- Kept behavior for other operations and preserved history/precision logic; the single modified file is `BigCalculator/Pages/Index.razor`.

### Testing
- Attempted to run `dotnet restore /workspace/BigCalculator/BigCalculator/BigCalculator.csproj`, but `dotnet` was not available so the restore could not be executed (failed).
- No automated unit or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a3860f30883289b776ef926c0f079)