### PR TITLE
Tighten header and section spacing

### DIFF
--- a/BigCalculator/Layout/MainLayout.razor
+++ b/BigCalculator/Layout/MainLayout.razor
@@ -11,13 +11,13 @@
 <MudSnackbarProvider />
 
 <MudLayout>
-    <MudAppBar>
+    <MudAppBar Dense="true">
         <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="@((e) => DrawerToggle())" />
 
         <!-- Beautiful Title Section -->
         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="ml-2">
             <MudIcon Icon="@Icons.Material.Filled.Calculate" Color="Color.Inherit" Size="Size.Medium" />
-            <MudText Typo="Typo.h6" Color="Color.Inherit" Class="fw-bold">
+            <MudText Typo="Typo.subtitle1" Color="Color.Inherit" Class="fw-bold">
                 BigCalculator.org
             </MudText>
             <MudChip T="string" Size="Size.Small" Color="Color.Secondary" Variant="Variant.Outlined" Class="ml-2">
@@ -92,6 +92,7 @@
     {
         MyCustomTheme.PaletteDark.Primary = "#b78c38";
         MyCustomTheme.PaletteDark.Secondary = Colors.Green.Accent4;
-        MyCustomTheme.PaletteDark.AppbarBackground = Colors.Red.Default;
+        MyCustomTheme.PaletteDark.AppbarBackground = "#d64a4a";
+        MyCustomTheme.PaletteLight.AppbarBackground = "#d64a4a";
     }
 }

--- a/BigCalculator/Pages/Index.razor
+++ b/BigCalculator/Pages/Index.razor
@@ -17,7 +17,7 @@
     </MudAlert>
 }
 
-<MudPaper Class="pa-4 pa-sm-8 pa-md-16 ma-2" Elevation="3">
+<MudPaper Class="pt-3 pb-4 px-4 px-sm-6 px-md-8 ma-2" Elevation="3">
     <!-- Input A -->
     <MudPaper Elevation="1" Class="d-flex align-center justify-center ma-2 ma-md-4">
         <MudTextField Lines="3"
@@ -160,7 +160,7 @@
     </MudPaper>
 
     <!-- Quick Actions -->
-    <MudPaper Class="pa-3 ma-2 ma-md-4" Elevation="1">
+    <MudPaper Class="py-2 px-3 mx-2 mt-2 mb-1 mx-md-4" Elevation="1">
         <MudStack Row="true" Spacing="2" Wrap="Wrap.Wrap" Justify="Justify.Center" Class="d-flex flex-wrap">
             <MudButton OnClick="ClearAll" StartIcon="@Icons.Material.Filled.Clear" Color="Color.Warning" Size="Size.Small">
                 Clear All
@@ -176,8 +176,8 @@
 </MudPaper>
 
 <!-- Enhanced History Section with Better Responsive Layout -->
-<MudPaper Class="pa-4 pa-sm-8 pa-md-16 ma-2" Elevation="3">
-    <MudText Typo="Typo.h6" Class="mb-4">Calculation History</MudText>
+<MudPaper Class="pt-3 pb-4 px-4 px-sm-6 px-md-8 mt-1 mb-2 mx-2" Elevation="3">
+    <MudText Typo="Typo.h6" Class="mb-3">Calculation History</MudText>
     <MudStack Reverse="true" Spacing="2">
         @foreach (var (result, index) in resultHistories.Select((r, i) => (r, i)))
         {


### PR DESCRIPTION
### Motivation
- Reduce the visual dominance of the red app bar and make the header less tall for a cleaner top-of-page appearance.
- Reduce excessive vertical spacing around input fields, quick-action buttons, result area, and history to make the UI more compact.
- Improve consistency between light and dark themes by applying the softened appbar color to both palettes.

### Description
- Made the app bar denser by setting `MudAppBar Dense="true"` and changed the title typography from `Typo.h6` to `Typo.subtitle1` in `Layout/MainLayout.razor` to shrink the header height.
- Softened the red app bar color by setting `MyCustomTheme.PaletteDark.AppbarBackground = "#d64a4a"` and added `MyCustomTheme.PaletteLight.AppbarBackground = "#d64a4a"` in `Layout/MainLayout.razor`.
- Tightened padding for the main calculator container and calculation history by replacing `pa-4 pa-sm-8 pa-md-16` with `pt-3 pb-4 px-4 px-sm-6 px-md-8` and reduced the history heading margin from `mb-4` to `mb-3` in `Pages/Index.razor`.
- Reduced spacing around the quick actions area by changing the `MudPaper` wrapper to use `py-2 px-3 mx-2 mt-2 mb-1 mx-md-4` in `Pages/Index.razor`.

### Testing
- Attempted to run the app with `dotnet run --project /workspace/BigCalculator/BigCalculator/BigCalculator.csproj`, but the `dotnet` command was not available in the environment, so the app could not be launched.
- No automated unit or integration tests were executed due to the missing `.NET` runtime in this environment.
- Changes were committed locally and file diffs reviewed to confirm the intended edits were applied successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b0c776458832893fa0ff08e0590c4)